### PR TITLE
Improve recommended handling of NTS NAKs

### DIFF
--- a/draft-ietf-ntp-using-nts-for-ntp.xml
+++ b/draft-ietf-ntp-using-nts-for-ntp.xml
@@ -945,8 +945,10 @@
           Unique Identifier matches that of an outstanding request. If
           this check fails, the packet MUST be discarded without
           further processing. If this check passes, the client SHOULD
-          discard all cookies and AEAD keys associated with the server
-          which sent the NAK and initiate a fresh NTS-KE handshake.
+          wait until the next poll for a valid NTS-protected response
+          and if none is received, discard all cookies and AEAD keys
+          associated with the server which sent the NAK and initiate a
+          fresh NTS-KE handshake.
         </t>
       </section>
     </section>


### PR DESCRIPTION
An attacker who can observe traffic between server and client, but not drop any packets (however unlikely that is) shouldn't be able to easily reset the association with an NTS NAK. I think the client can wait a bit for the real response from the server before dropping the cookies and keys.